### PR TITLE
Add git to the deploy image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ RUN apk add -q --no-cache \
   coreutils \
   curl \
   docker \
+  git \
   grep \
   jq


### PR DESCRIPTION
We seem to have lost `git` after updating the `kd` base image.