### PR TITLE
Add a generic way to get node package version vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,6 @@ RUN wget -q "https://storage.googleapis.com/kubernetes-release/release/v${KUBECT
  && chmod +x "/usr/bin/kubectl" \
  && chmod +x "/usr/bin/kd"
 
+COPY get-package-details.sh /get-package-details.sh
 
 CMD ["bash"]

--- a/get-package-details.sh
+++ b/get-package-details.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+export VERSION=`cat package.json | jq -r '.version'`
+export MAJOR=`echo -n "${VERSION}" | awk -F '.' '{print $1}'`
+export MINOR=`echo -n "${VERSION}" | awk -F '.' '{print $2}'`
+export PATCH=`echo -n "${VERSION}" | awk -F '.' '{print $3}'`


### PR DESCRIPTION
Provide a simple reusable way to get the version of the local node package (from `package.json`).