### PR TITLE
Get package version when available

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ matrix:
   MAJOR:
     - 2
   MINOR:
-    - 0
+    - 1
   PATCH:
     - 0
   DOCKER_USERNAME:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,11 @@ RUN apk add -q --no-cache \
   sed \
  && pip3 install -q docker-compose
 
+COPY get-package-details.sh /usr/bin/get-package-details
+
 RUN wget -q "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -O "/usr/bin/kubectl" \
  && wget -q "https://github.com/UKHomeOffice/kd/releases/download/v${KD_VERSION}/kd_linux_amd64" -O "/usr/bin/kd" \
  && chmod +x "/usr/bin/kubectl" \
  && chmod +x "/usr/bin/kd"
-
-COPY get-package-details.sh /get-package-details.sh
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add -q --no-cache \
  && pip3 install -q docker-compose
 
 COPY get-package-details.sh /usr/bin/get-package-details
+COPY set-tags.sh /usr/bin/set-tags
 
 RUN wget -q "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -O "/usr/bin/kubectl" \
  && wget -q "https://github.com/UKHomeOffice/kd/releases/download/v${KD_VERSION}/kd_linux_amd64" -O "/usr/bin/kd" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY get-package-details.sh /usr/bin/get-package-details
 RUN wget -q "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -O "/usr/bin/kubectl" \
  && wget -q "https://github.com/UKHomeOffice/kd/releases/download/v${KD_VERSION}/kd_linux_amd64" -O "/usr/bin/kd" \
  && chmod +x "/usr/bin/kubectl" \
- && chmod +x "/usr/bin/kd"
+ && chmod +x "/usr/bin/kd" \
+ && printf '\nsource /usr/bin/get-package-details\n' >> /root/.bashrc
 
 CMD ["bash"]

--- a/get-package-details.sh
+++ b/get-package-details.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-export VERSION=`cat package.json | jq -r '.version'`
-export MAJOR=`echo -n "${VERSION}" | awk -F '.' '{print $1}'`
-export MINOR=`echo -n "${VERSION}" | awk -F '.' '{print $2}'`
-export PATCH=`echo -n "${VERSION}" | awk -F '.' '{print $3}'`
+if [ -f package.json ] ; then
+  export VERSION=`cat package.json | jq -r '.version'`
+  export MAJOR=`echo -n "${VERSION}" | awk -F '.' '{print $1}'`
+  export MINOR=`echo -n "${VERSION}" | awk -F '.' '{print $2}'`
+  export PATCH=`echo -n "${VERSION}" | awk -F '.' '{print $3}'`
+fi

--- a/get-package-details.sh
+++ b/get-package-details.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-if [ -f package.json ] ; then
-  export VERSION=`cat package.json | jq -r '.version'`
+package=${1:-package.json}
+
+if [ -f ${package} ] ; then
+  export VERSION=`cat ${package} | jq -r '.version'`
   export MAJOR=`echo -n "${VERSION}" | awk -F '.' '{print $1}'`
   export MINOR=`echo -n "${VERSION}" | awk -F '.' '{print $2}'`
   export PATCH=`echo -n "${VERSION}" | awk -F '.' '{print $3}'`

--- a/get-package-details.sh
+++ b/get-package-details.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 export VERSION=`cat package.json | jq -r '.version'`
 export MAJOR=`echo -n "${VERSION}" | awk -F '.' '{print $1}'`

--- a/set-tags.sh
+++ b/set-tags.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "${VERSION}-${DRONE_BUILD_NUMBER}-${DRONE_COMMIT:0:10},${VERSION},${MAJOR}-${MINOR},${MAJOR},latest" > .tags


### PR DESCRIPTION
These changes should make the following environment variables available when `lev-ci` is used in a drone job where the local project has a `package.json` file:
 - VERSION
 - MAJOR
 - MINOR
 - PATCH

These should be available without any downstream actions, but `get-package-details` can be called (as it should be part of the standard `$PATH`) explicitly:
 - ```source get-package-details # if there is a ./package.json file```
 - ```source get-package-details /path/to/package.json```