### PR TITLE
Ensure version variable exists

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ matrix:
   MAJOR:
     - 3
   MINOR:
-    - 0
+    - 1
   PATCH:
     - 0
   DOCKER_USERNAME:

--- a/set-tags.sh
+++ b/set-tags.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+[[ -z "${VERSION}" ]] && source get-package-details
 echo "${VERSION}-${DRONE_BUILD_NUMBER}-${DRONE_COMMIT:0:10},${VERSION},${MAJOR}-${MINOR},${MAJOR},latest" > .tags


### PR DESCRIPTION
...otherwise the image tagging part of the CI pipeline will fail.

NOTE: this should fix the broken `lev-report` deployment.