### PR TITLE
Add python2 for node-gyp

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ matrix:
   MAJOR:
     - 3
   MINOR:
-    - 3
+    - 4
   PATCH:
     - 0
   DOCKER_USERNAME:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN apk add -q --no-cache \
   openssl \
   py3-pip \
   py3-paramiko \
+  python \
   sed \
- && pip3 install -q docker-compose \
- && cd /usr/bin && ln -s python3 python
+ && pip3 install -q docker-compose
 
 COPY get-package-details.sh /usr/bin/get-package-details
 COPY set-tags.sh /usr/bin/set-tags


### PR DESCRIPTION
It seems older versions of `node-gyp` require `python2`.